### PR TITLE
Implement statefulnes: persist newstate and use it as oldstate in the next call

### DIFF
--- a/app/src/main/java/com/hg4/oopalgorithm/oopalgorithm/IntentsReceiver.java
+++ b/app/src/main/java/com/hg4/oopalgorithm/oopalgorithm/IntentsReceiver.java
@@ -11,11 +11,14 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+
+
 class Constants {
     static public final String XDRIP_PLUS_LIBRE_DATA = "com.eveningoutpost.dexdrip.LIBRE_DATA";
     static public final String LIBRE_DATA_BUFFER = "com.eveningoutpost.dexdrip.Extras.DATA_BUFFER";
     static public final String LIBRE_DATA_TIMESTAMP = "com.eveningoutpost.dexdrip.Extras.TIMESTAMP";
     static public final String XDRIP_PLUS_NS_EMULATOR = "com.eveningoutpost.dexdrip.NS_EMULATOR";
+    static public final String LIBRE_SN = "com.eveningoutpost.dexdrip.Extras.LIBRE_SN";
 }
 
 public class IntentsReceiver extends BroadcastReceiver {
@@ -25,17 +28,16 @@ public class IntentsReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         Log.e(TAG,"we are inside the broadcast reciever");
 
+        String sensorid = intent.getStringExtra(Constants.LIBRE_SN);
         String packet_file = intent.getStringExtra("packet");
-        String old_state_file = intent.getStringExtra("old_state");//"/data/local/tmp/new_state_20171002_165943.dat";
+
         long timestamp;
 
         Log.e(TAG,"packet_file = " + packet_file);
-        Log.e(TAG,"old_state_file = " + old_state_file);
+        Log.e(TAG,"dabear: sensorid = " + sensorid);
+
         byte[] packet;
-        byte[] oldState = {(byte)0xff, (byte)0xff, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00,
-                (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00,
-                (byte)0xff, (byte)0xff, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00,
-                (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};;
+
         if(packet_file != null) {
             packet = Utils.readBinaryFile(packet_file);
         } else {
@@ -43,21 +45,20 @@ public class IntentsReceiver extends BroadcastReceiver {
         }
         timestamp = intent.getLongExtra(Constants.LIBRE_DATA_TIMESTAMP, 0);
 
+
         Log.e(TAG,"byte packet = " + Utils.byteArrayToHex(packet));
 
-        if(old_state_file != null) {
-            oldState = Utils.readBinaryFile(old_state_file);
-        }
-        Log.i(TAG,"byte oldState = " + Utils.byteArrayToHex(oldState));
 
-        if(packet == null || oldState == null) {
-            Log.i(TAG,"packet or oldState are null - returning without sending a data file " + packet + oldState);
+
+        if(packet == null) {
+            Log.i(TAG,"packet is null - returning without sending a data file " + packet );
             return;
         }
 
 
 
-        OOPResults oOPResults = AlgorithmRunner.RunAlgorithm(timestamp, context, packet, oldState);
+
+        OOPResults oOPResults = AlgorithmRunner.RunAlgorithm(timestamp, context, packet, false, sensorid);
         double sgv = oOPResults.currentBg;
         Log.i(TAG,"RunAlgorithm returned " + sgv);
         if(sgv > 0) {

--- a/app/src/main/java/com/hg4/oopalgorithm/oopalgorithm/MainActivity.java
+++ b/app/src/main/java/com/hg4/oopalgorithm/oopalgorithm/MainActivity.java
@@ -99,7 +99,7 @@ public class MainActivity extends AppCompatActivity {
                 (byte)0x14, (byte)0x07, (byte)0x96, (byte)0x80, (byte)0x5a, (byte)0x00, (byte)0xed, (byte)0xa6,
                 (byte)0x0e, (byte)0x6e, (byte)0x1a, (byte)0xc8, (byte)0x04, (byte)0xdd, (byte)0x58, (byte)0x6d};
 
-        int sgv = (int) AlgorithmRunner.RunAlgorithm(0, getApplicationContext(), packet, null).currentBg;
+        int sgv = (int) AlgorithmRunner.RunAlgorithm(0, getApplicationContext(), packet, true, null).currentBg;
 
         if(sgv == 63) {
             tv.setText("Algorithm worked correctly");

--- a/app/src/main/java/com/no/bjorninge/librestate/LibreState.java
+++ b/app/src/main/java/com/no/bjorninge/librestate/LibreState.java
@@ -1,0 +1,100 @@
+package com.no.bjorninge.librestate;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Base64;
+import android.util.Log;
+
+import java.util.Arrays;
+
+public class LibreState {
+    public static String TAG = "LibreState";
+    private static String savedState =  "savedstate";
+    private static String savedSensorId = "savedstatesensorid";
+
+    private static byte[] defaultState = {(byte) 0xff, (byte) 0xff, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0xff, (byte) 0xff, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00};
+
+    public static byte[] getDefaultState(){
+        return Arrays.copyOf(defaultState, defaultState.length);
+    }
+
+    private static byte[] getAndSaveDefaultStateForSensor(String sensorid, Context context){
+        byte[] newstate1 = getDefaultState();
+        saveSensorState(sensorid, newstate1, context);
+        return newstate1;
+    }
+
+    public static void saveSensorState(String sensorid, byte[] state, Context context) {
+
+        if (sensorid == null) {
+            Log.e(TAG, "dabear: tried to save sensorstate, but sensorid was null! ");
+            return;
+        }
+        if (state == null) {
+            Log.e(TAG, "dabear: tried to save sensorstate, but state was null! ");
+            return;
+        }
+
+        SharedPreferences prefs = context.getSharedPreferences(
+                TAG, Context.MODE_PRIVATE);
+        SharedPreferences.Editor edit = prefs.edit();
+
+        edit.clear();
+        edit.putString(savedState, Base64.encodeToString(state, Base64.NO_WRAP));
+        edit.putString(savedSensorId, sensorid);
+
+        // we really want this to be sync
+        // as we depend on these preferences for the next calls to algorunner
+        edit.commit();
+
+        Log.e(TAG, "dabear: saved newState for sensorid " + sensorid + ": " + Arrays.toString(state));
+
+    }
+
+
+    public static byte[] getStateForSensor(String sensorid, Context context) {
+
+        if(sensorid == null) {
+            Log.e(TAG,"dabear: shortcutting gettingstate, as sensorid was null" );
+            return getDefaultState();
+        }
+
+        SharedPreferences prefs = context.getSharedPreferences(
+                TAG, Context.MODE_PRIVATE);
+        String savedstate = prefs.getString(savedState, "-NA-");
+        String savedstatesensorid = prefs.getString(savedSensorId, "-NA-");
+
+
+
+        if(savedstate.equals("-NA-") || savedstatesensorid.equals("-NA-")) {
+            Log.e(TAG,"dabear: returning defaultstate to caller, we did not have sensordata stored on disk" );
+
+            return getAndSaveDefaultStateForSensor(sensorid, context);
+        }
+
+        if(!savedstatesensorid.equals(sensorid)) {
+            Log.e(TAG,"dabear: returning defaultstate to caller, new sensorid detected: " + sensorid );
+
+            return getAndSaveDefaultStateForSensor(sensorid, context);
+        }
+
+        byte[] decoded;
+
+        //todo: more checks here?
+        if(savedstatesensorid.equals(sensorid)) {
+            try{
+                decoded = Base64.decode(savedstate, Base64.DEFAULT);
+                return decoded;
+            } catch (IllegalArgumentException ex) {
+                Log.e(TAG,"dabear: could not decode sensorstate" );
+            }
+        }
+
+        Log.e(TAG,"dabear: returning defaultstate to caller" );
+        return getDefaultState();
+    }
+
+}


### PR DESCRIPTION
This is a working proof-of-concept of statefulnes. This basically smoothes glucose values by providing the newstate output of the processScan dataprocessing native as oldstate input into the next call to processScan. This makes libreoopalgorithm more closely match how the offical reader work.

![image](https://user-images.githubusercontent.com/442324/42134219-42ed5f5e-7d37-11e8-8fdc-01c2fa563f98.png)



Please also see the branch I've created here https://github.com/dabear/LibreOOPAlgorithm/commits/statefulnes-w-comparision-upload which compares the stateful and stateless methods of calling the algorithm.

The results of the statefulnes-w-comparision-upload branch is continously uploaded to http://remoteblobstorage.azurewebsites.net/api/FetchContents?accesstoken=blober1-fa355ab4980e061e 


